### PR TITLE
Integrate WASM storage (add DR hash/ID input parameter, args for WASM binary

### DIFF
--- a/src/SedaOracle.sol
+++ b/src/SedaOracle.sol
@@ -61,7 +61,8 @@ contract SedaOracle {
     /// @notice Post a data request
     function postDataRequest(string calldata value, bytes calldata wasmId, bytes[][] calldata wasmArgs) public {
         data_request_count++;
-        bytes32 dr_id = keccak256(abi.encodePacked(data_request_count, value, block.chainid));
+        bytes32 dr_id =
+            keccak256(abi.encodePacked(data_request_count, value, block.chainid, wasmId, abi.encode(wasmArgs)));
         data_request_pool[dr_id] = SedaOracleLib.DataRequest(
             dr_id, data_request_count, value, data_request_pool_array.length, wasmId, wasmArgs
         );

--- a/src/SedaOracle.sol
+++ b/src/SedaOracle.sol
@@ -7,6 +7,8 @@ library SedaOracleLib {
         uint256 nonce;
         string value;
         uint256 index_in_pool;
+        bytes wasm_id;
+        bytes[][] wasm_args;
     }
 
     struct DataResult {
@@ -57,11 +59,12 @@ contract SedaOracle {
     }
 
     /// @notice Post a data request
-    function postDataRequest(string calldata value) public {
+    function postDataRequest(string calldata value, bytes calldata wasmId, bytes[][] calldata wasmArgs) public {
         data_request_count++;
         bytes32 dr_id = keccak256(abi.encodePacked(data_request_count, value, block.chainid));
-        data_request_pool[dr_id] =
-            SedaOracleLib.DataRequest(dr_id, data_request_count, value, data_request_pool_array.length);
+        data_request_pool[dr_id] = SedaOracleLib.DataRequest(
+            dr_id, data_request_count, value, data_request_pool_array.length, wasmId, wasmArgs
+        );
         data_request_pool_array.push(dr_id);
         emit DataRequestPosted(dr_id, value, data_request_count, msg.sender);
     }

--- a/test/SedaOracle.t.sol
+++ b/test/SedaOracle.t.sol
@@ -104,7 +104,9 @@ contract SedaOracleTest is Test {
         uint256 nonce = 1;
         string memory value = "test";
         uint256 chainId = 31337;
-        bytes32 test_hash = keccak256(abi.encodePacked(nonce, value, chainId));
+        bytes32 wasmId = "wasm_id";
+        bytes memory wasmArgs = abi.encode(_getTestWasmArgs());
+        bytes32 test_hash = keccak256(abi.encodePacked(nonce, value, chainId, wasmId, wasmArgs));
 
         bytes memory test_hash_bytes = new bytes(32);
         assembly {

--- a/test/SedaOracle.t.sol
+++ b/test/SedaOracle.t.sol
@@ -11,12 +11,11 @@ contract SedaOracleTest is Test {
         oracle = new SedaOracle();
     }
 
-    function _getTestWasmArgs() private pure returns (bytes[][] memory) {
-        bytes[][] memory args = new bytes[][](1);
-        args[0] = new bytes[](2);
-        args[0][0] = bytes("arg1");
-        args[0][1] = bytes("arg2");
-        return args;
+    function _getTestWasmArgs() private pure returns (bytes[] memory) {
+        bytes[] memory wasm_args = new bytes[](2);
+        wasm_args[0] = "arg1";
+        wasm_args[1] = "arg2";
+        return wasm_args;
     }
 
     function testPostDataRequest() public {
@@ -102,11 +101,12 @@ contract SedaOracleTest is Test {
 
     function testHash() public {
         uint256 nonce = 1;
-        string memory value = "test";
+        string memory value = "hello world";
         uint256 chainId = 31337;
-        bytes32 wasmId = "wasm_id";
-        bytes memory wasmArgs = abi.encode(_getTestWasmArgs());
-        bytes32 test_hash = keccak256(abi.encodePacked(nonce, value, chainId, wasmId, wasmArgs));
+        bytes memory wasmId = "wasm_id";
+        bytes[] memory wasmArgs = _getTestWasmArgs();
+
+        bytes32 test_hash = oracle.hashDataRequest(nonce, value, chainId, wasmId, wasmArgs);
 
         bytes memory test_hash_bytes = new bytes(32);
         assembly {


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

Data requests have different requirements and should be resolved using different techniques via selecting a WASM binary to execute them.

## Explanation of Changes

Add two more properties to data requests and related function for creating DRs: WASM binary ID and args.

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

- Updated tests to pass wasm id, args in `postDataRequest()`
- New private helper function to generate args: `_getTestWasmArgs()`

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Closes #10
