### PR TITLE
✨ Add `tally_gas_limit` property when posting and storing data request

### DIFF
--- a/.github/workflows/test-fmt.yml
+++ b/.github/workflows/test-fmt.yml
@@ -18,4 +18,4 @@ jobs:
         run: forge fmt --check
 
       - name: Run tests
-        run: forge test -vvv
+        run: forge test -vvv --via-ir

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ curl -L https://foundry.paradigm.xyz | bash
 The [Foundry book](https://book.getfoundry.sh/reference/forge/) is a great reference for getting started.
 
 ```bash
-forge build
-forge test
+forge build --via-ir
+forge test -vv --via-ir
 forge fmt
 ```
 

--- a/src/SedaOracle.sol
+++ b/src/SedaOracle.sol
@@ -15,8 +15,10 @@ library SedaOracleLib {
         uint16 replication_factor;
         /// Amount of SEDA tokens per gas unit
         uint128 gas_price;
-        /// Maximum of gas units to be used
+        /// Maximum of gas units to be used by data request executors
         uint128 gas_limit;
+        /// Maximum of gas units to be used in the tallying process
+        uint128 tally_gas_limit;
     }
 
     struct DataRequest {
@@ -37,8 +39,10 @@ library SedaOracleLib {
         uint16 replication_factor;
         /// Amount of SEDA tokens per gas unit
         uint128 gas_price;
-        /// Maximum of gas units to be used
+        /// Maximum of gas units to be used by data request executors
         uint128 gas_limit;
+        /// Maximum of gas units to be used in the tallying process
+        uint128 tally_gas_limit;
         /// Public info attached to DR
         bytes32 memo;
         // Internal bookkeeping
@@ -129,6 +133,7 @@ contract SedaOracle {
             inputs.replication_factor,
             inputs.gas_price,
             inputs.gas_limit,
+            inputs.tally_gas_limit,
             memo,
             data_request_pool_array.length,
             data_request_count
@@ -191,6 +196,7 @@ contract SedaOracle {
                 inputs.dr_inputs,
                 inputs.gas_limit,
                 inputs.gas_price,
+                inputs.tally_gas_limit,
                 memo,
                 inputs.replication_factor,
                 inputs.tally_binary_id,

--- a/test/SedaOracle.t.sol
+++ b/test/SedaOracle.t.sol
@@ -24,7 +24,8 @@ contract SedaOracleTest is Test {
             tally_inputs: "tally_inputs",
             replication_factor: 123,
             gas_price: 456,
-            gas_limit: 789
+            gas_limit: 789,
+            tally_gas_limit: 101112
         });
     }
 
@@ -75,14 +76,14 @@ contract SedaOracleTest is Test {
 
         bytes32 dr_id = oracle.getDataRequestsFromPool(0, 1)[0].id;
 
-        (, bytes32 expected_id,,,,,,,,,,) = oracle.data_request_pool(dr_id);
+        (, bytes32 expected_id,,,,,,,,,,,) = oracle.data_request_pool(dr_id);
         assertEq(expected_id, dr_id);
     }
 
     function testPostDataResult() public {
         // post a data request and assert the associated result is non-existent
         oracle.postDataRequest(_getDataRequestInputs());
-        (, bytes32 dr_id,,,,,,,,,,) = oracle.data_request_pool(oracle.getDataRequestsFromPool(0, 1)[0].id);
+        (, bytes32 dr_id,,,,,,,,,,,) = oracle.data_request_pool(oracle.getDataRequestsFromPool(0, 1)[0].id);
         (, bytes32 res_id_nonexistent,,,,,,,) = oracle.data_request_id_to_result(dr_id);
         assertEq(res_id_nonexistent, 0);
 
@@ -152,7 +153,8 @@ contract SedaOracleTest is Test {
             tally_inputs: "tally_inputs",
             replication_factor: 3,
             gas_price: 10,
-            gas_limit: 10
+            gas_limit: 10,
+            tally_gas_limit: 10
         });
 
         // calculate data request hash


### PR DESCRIPTION
<!--
    Thank you for submitting the PR! We appreciate you spending the time to work on these changes.

    Please help us understand your motivation by explaining why you decided to make this change.

    Happy contributing!
-->

## Motivation

The gas limit for tally needs to separate from the gas limit used by data request executors when resolving requests to disincentive DREs from reporting too much gas usage where the tally execution would fail.



## Explanation of Changes

<!-- Please explain why you made these changes the way you did.  -->

- Added `tally_gas_limit` to a few structs related to posting and storing data requests and calculating the ID hash
- Updated complier/README to use [IR-based codegen](https://docs.soliditylang.org/en/latest/ir-breaking-changes.html) since our structs have too many properties to compile directly to EVM opcodes, giving "stack too deep" error

## Testing

<!--
    How do you test these changes?
	What command do you run to test these changes specifically?
-->

N/A, it is only used a stored property at the moment.

## Related PRs and Issues

<!--
    Please link to any relevant Issues and PRs.
    Also, please link to any relevant SIPs.
-->

Closes #20 
