### PR TITLE
Add code coverage command

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,0 +1,6 @@
+module.exports = {
+  mocha: {
+    grep: '[Gg]as.*[Aa]nalysis',
+    invert: true,
+  },
+};

--- a/README.md
+++ b/README.md
@@ -125,15 +125,20 @@ Available commands:
 
 2. Run tests:
    ```bash
-   bun test
+   bun run test
    ```
 
-3. Run tests with gas reporting:
+3. Run tests with coverage:
+   ```bash
+   bun run test:coverage
+   ```
+
+4. Run tests with gas reporting:
    ```bash
    bun run test:gas
    ```
 
-4. Lint and format code:
+5. Lint and format code:
    ```bash
    # Run all checks (lint + format)
    bun run check
@@ -151,7 +156,7 @@ Available commands:
    bun run format:sol:fix
    ```
 
-5. Other utilities:
+6. Other utilities:
    ```bash
    # Generate test vectors
    bun run gen:testvectors

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "prepublish": "bun run clean && bun run compile",
     "seda": "hardhat seda",
     "test": "hardhat test --grep \"^(?!.*[Gg]as.*[Aa]nalysis).*$\"",
+    "test:coverage": "COVERAGE=true hardhat coverage",
     "test:gas": "REPORT_GAS=true hardhat test --grep \"[Gg]as.*[Aa]nalysis\""
   },
   "dependencies": {


### PR DESCRIPTION
## Motivation

Allow us to easily keep track of code coverage in our tests. This does not yet add the report to PRs though, leaving that as a separate step.

## Explanation of Changes

Had to add the `.solcover.js` to ignore the gas analysis tests, as the `--grep` flag is not supported by `hardhat coverage`.

## Testing

Run `bun run test:coverage` and observe the output.

## Related PRs and Issues

N.A.