### PR TITLE
feat: update to support devnet 5

### DIFF
--- a/contracts/libraries/SedaDataTypes.sol
+++ b/contracts/libraries/SedaDataTypes.sol
@@ -74,7 +74,7 @@ library SedaDataTypes {
         /// The timestamp of the block the data result is included
         uint64 blockTimestamp;
         /// Gas used by the complete data request execution
-        uint64 gasUsed;
+        uint128 gasUsed;
         // Fields from Data Request Execution
         /// Payback address set by the relayer
         bytes paybackAddress;
@@ -130,7 +130,7 @@ library SedaDataTypes {
                     keccak256(result.result),
                     bytes8(result.blockHeight),
                     bytes8(result.blockTimestamp),
-                    bytes8(result.gasUsed),
+                    bytes16(result.gasUsed),
                     keccak256(result.paybackAddress),
                     keccak256(result.sedaPayload)
                 )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seda-protocol/evm",
-  "version": "0.0.4",
+  "version": "0.5.0",
   "description": "EVM smart contracts enabling any blockchain to connect with the SEDA decentralized network",
   "keywords": ["ethereum", "evm", "oracle", "seda", "smart-contracts", "solidity", "cross-chain"],
   "author": "SEDA Protocol <info@seda.xyz>",

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -61,7 +61,7 @@ export function deriveDataResultId(dataResult: CoreResultTypes.ResultStruct): st
       ethers.keccak256(dataResult.result),
       padBigIntToBytes(BigInt(dataResult.blockHeight), 8),
       padBigIntToBytes(BigInt(dataResult.blockTimestamp), 8),
-      padBigIntToBytes(BigInt(dataResult.gasUsed), 8),
+      padBigIntToBytes(BigInt(dataResult.gasUsed), 16),
       ethers.keccak256(dataResult.paybackAddress),
       ethers.keccak256(dataResult.sedaPayload),
     ]),


### PR DESCRIPTION
## Motivation

Update required to support latest changes on Devnet 5.

## Explanation of Changes

Changed the type of the result field `gas_used` to `u128`.

## Testing

Tests still work after updating a util function to derive result IDs.

## Related PRs and Issues

Closes #86 
