### PR TITLE
Serialise bigints as string with test-vectors

### DIFF
--- a/scripts/generateTestVectors.ts
+++ b/scripts/generateTestVectors.ts
@@ -69,6 +69,7 @@ const dataJSON = {
   results: results.map((result, index) => ({
     resultId: resultIds[index],
     ...result,
+    gasUsed: result.gasUsed.toString(),
   })),
   resultsTree: {
     root: resultsTree.root,


### PR DESCRIPTION
## Motivation

Make the generation script work again with the u128 changes.

## Explanation of Changes

JSON can't serialise a bigint.

## Testing

Generated new test vectors.

## Related PRs and Issues

See https://github.com/sedaprotocol/seda-chain/pull/471 for the newly generated test vectors.
