### PR TITLE
feat: support withdraw if request times out

### DIFF
--- a/contracts/core/SedaCoreV1.sol
+++ b/contracts/core/SedaCoreV1.sol
@@ -103,7 +103,7 @@ contract SedaCoreV1 is
             revert InvalidFeeAmount();
         }
 
-        // Call parent contract's postResult base implementation
+        // Call parent contract's postRequest base implementation
         bytes32 requestId = RequestHandlerBase.postRequest(inputs);
 
         // Store pending request and request details
@@ -141,7 +141,7 @@ contract SedaCoreV1 is
         (bytes32 resultId, address batchSender) = super.postResultAndGetBatchSender(result, batchHeight, proof);
 
         // Clean up state
-        _removeRequest(result.drId);
+        _removePendingRequest(result.drId);
         delete _storageV1().requestDetails[result.drId];
 
         // Fee distribution: handles three types of fees (request, result, batch)
@@ -248,7 +248,7 @@ contract SedaCoreV1 is
         uint256 totalRefund = details.requestFee + details.resultFee + details.batchFee;
 
         // Clean up state before transfer to prevent reentrancy
-        _removeRequest(requestId);
+        _removePendingRequest(requestId);
         delete _storageV1().requestDetails[requestId];
 
         // Transfer total fees to caller
@@ -348,7 +348,7 @@ contract SedaCoreV1 is
     /// @dev This function is internal to ensure that only the contract's internal logic can remove requests,
     /// maintaining proper state transitions and preventing unauthorized removals.
     /// @param requestId The ID of the request to remove
-    function _removeRequest(bytes32 requestId) internal {
+    function _removePendingRequest(bytes32 requestId) internal {
         _storageV1().pendingRequests.remove(requestId);
     }
 

--- a/contracts/core/SedaCoreV1.sol
+++ b/contracts/core/SedaCoreV1.sol
@@ -251,10 +251,10 @@ contract SedaCoreV1 is
         _removePendingRequest(requestId);
         delete _storageV1().requestDetails[requestId];
 
-        // Transfer total fees to caller
+        // Transfer total fees to data request creator
         if (totalRefund > 0) {
-            _transferFee(msg.sender, totalRefund);
-            emit FeeDistributed(requestId, msg.sender, totalRefund, FeeType.WITHDRAW);
+            _transferFee(details.requestor, totalRefund);
+            emit FeeDistributed(requestId, details.requestor, totalRefund, FeeType.WITHDRAW);
         }
     }
 

--- a/contracts/core/abstract/ResultHandlerBase.sol
+++ b/contracts/core/abstract/ResultHandlerBase.sol
@@ -109,7 +109,7 @@ abstract contract ResultHandlerBase is IResultHandler, Initializable {
     ) internal returns (bytes32, address) {
         bytes32 resultId = SedaDataTypes.deriveResultId(result);
         if (_resultHandlerStorage().results[result.drId].drId != bytes32(0)) {
-            revert ResultAlreadyExists(resultId);
+            revert ResultAlreadyExists(result.drId);
         }
 
         (bool isValid, address batchSender) = _resultHandlerStorage().sedaProver.verifyResultProof(

--- a/contracts/interfaces/IRequestHandler.sol
+++ b/contracts/interfaces/IRequestHandler.sol
@@ -7,8 +7,8 @@ import {SedaDataTypes} from "../libraries/SedaDataTypes.sol";
 /// @notice Interface for the Request Handler contract.
 interface IRequestHandler {
     error InvalidReplicationFactor();
-    error RequestAlreadyExists(bytes32);
-    error RequestNotFound(bytes32);
+    error RequestAlreadyExists(bytes32 requestId);
+    error RequestNotFound(bytes32 requestId);
     error FeeTransferFailed();
 
     event RequestPosted(bytes32 indexed requestId);

--- a/contracts/interfaces/IResultHandler.sol
+++ b/contracts/interfaces/IResultHandler.sol
@@ -6,9 +6,9 @@ import {SedaDataTypes} from "../libraries/SedaDataTypes.sol";
 /// @title IResultHandler
 /// @notice Interface for handling result posting and retrieval
 interface IResultHandler {
-    error InvalidResultProof(bytes32);
-    error ResultAlreadyExists(bytes32);
-    error ResultNotFound(bytes32);
+    error InvalidResultProof(bytes32 resultId);
+    error ResultAlreadyExists(bytes32 requestId);
+    error ResultNotFound(bytes32 requestId);
 
     event ResultPosted(bytes32 indexed resultId);
 

--- a/contracts/interfaces/ISedaCore.sol
+++ b/contracts/interfaces/ISedaCore.sol
@@ -29,11 +29,15 @@ interface ISedaCore is IResultHandler, IRequestHandler {
         REQUEST,
         RESULT,
         BATCH,
-        REFUND
+        REFUND,
+        WITHDRAW
     }
 
     /// @notice Error thrown when the fee amount is not equal to the sum of the request, result, and batch fees
     error InvalidFeeAmount();
+
+    error RequestNotTimedOut(bytes32 requestId, uint256 currentTime, uint256 timeoutTime);
+    error InvalidTimeoutPeriod();
 
     /// @notice Emitted when fees are distributed for a data request and result
     /// @param drId The unique identifier for the data request
@@ -52,6 +56,10 @@ interface ISedaCore is IResultHandler, IRequestHandler {
         uint256 additionalResultFee,
         uint256 additionalBatchFee
     );
+
+    /// @notice Emitted when the timeout period is updated
+    /// @param newTimeoutPeriod The new timeout period in seconds
+    event TimeoutPeriodUpdated(uint256 newTimeoutPeriod);
 
     /// @notice Retrieves a paginated list of pending requests
     /// @param offset The starting position in the list

--- a/tasks/common/deploy/proxy.ts
+++ b/tasks/common/deploy/proxy.ts
@@ -11,7 +11,7 @@ export type UupsContracts = {
     constructorArgs: [ProverDataTypes.BatchStruct];
   };
   SedaCoreV1: {
-    constructorArgs: [string];
+    constructorArgs: [string, number];
   };
 };
 

--- a/test/core/ResultHandler.test.ts
+++ b/test/core/ResultHandler.test.ts
@@ -47,7 +47,7 @@ describe('ResultHandler', () => {
   }
 
   describe('deriveResultId', () => {
-    it('should generate consistent data result IDs', async () => {
+    it('generates consistent result IDs', async () => {
       const { core, data } = await loadFixture(deployResultHandlerFixture);
 
       const resultIdFromUtils = deriveDataResultId(data.results[0]);
@@ -56,7 +56,7 @@ describe('ResultHandler', () => {
       expect(resultId).to.equal(resultIdFromUtils);
     });
 
-    it('should generate different IDs for different results', async () => {
+    it('generates unique IDs for different results', async () => {
       const { core, data } = await loadFixture(deployResultHandlerFixture);
 
       const id1 = await core.deriveResultId.staticCall(data.results[0]);
@@ -67,7 +67,7 @@ describe('ResultHandler', () => {
   });
 
   describe('postResult', () => {
-    it('should successfully post a result and read it back', async () => {
+    it('posts result and retrieves it successfully', async () => {
       const { core, data } = await loadFixture(deployResultHandlerFixture);
 
       await core.postResult(data.results[0], 0, data.proofs[0]);
@@ -76,18 +76,17 @@ describe('ResultHandler', () => {
       compareResults(postedResult, data.results[0]);
     });
 
-    it('should fail to post a result that already exists', async () => {
+    it('reverts when posting duplicate result', async () => {
       const { core, data } = await loadFixture(deployResultHandlerFixture);
 
       await core.postResult(data.results[0], 0, data.proofs[0]);
 
-      const resultId = deriveDataResultId(data.results[0]);
       await expect(core.postResult(data.results[0], 0, data.proofs[0]))
         .to.be.revertedWithCustomError(core, 'ResultAlreadyExists')
-        .withArgs(resultId);
+        .withArgs(data.results[0].drId);
     });
 
-    it('should fail to post a result with invalid proof', async () => {
+    it('reverts when proof is invalid', async () => {
       const { core, data } = await loadFixture(deployResultHandlerFixture);
 
       const resultId = deriveDataResultId(data.results[1]);
@@ -96,7 +95,7 @@ describe('ResultHandler', () => {
         .withArgs(resultId);
     });
 
-    it('should emit a ResultPosted event', async () => {
+    it('emits ResultPosted event', async () => {
       const { core, data } = await loadFixture(deployResultHandlerFixture);
 
       await expect(core.postResult(data.results[0], 0, data.proofs[0]))
@@ -104,7 +103,7 @@ describe('ResultHandler', () => {
         .withArgs(deriveDataResultId(data.results[0]));
     });
 
-    it('should fail to post a result with empty proof', async () => {
+    it('reverts when proof is empty', async () => {
       const { core, data } = await loadFixture(deployResultHandlerFixture);
 
       const resultId = deriveDataResultId(data.results[0]);
@@ -113,7 +112,7 @@ describe('ResultHandler', () => {
         .withArgs(resultId);
     });
 
-    it('should fail to post a result with invalid drId', async () => {
+    it('reverts when drId is invalid', async () => {
       const { core, data } = await loadFixture(deployResultHandlerFixture);
 
       const invalidResult = { ...data.results[0], drId: ethers.ZeroHash };
@@ -125,7 +124,7 @@ describe('ResultHandler', () => {
   });
 
   describe('getResult', () => {
-    it('should revert with ResultNotFound for non-existent result id', async () => {
+    it('reverts for non-existent result', async () => {
       const { core } = await loadFixture(deployResultHandlerFixture);
 
       const nonExistentId = ethers.ZeroHash;
@@ -134,7 +133,7 @@ describe('ResultHandler', () => {
         .withArgs(nonExistentId);
     });
 
-    it('should return the correct result for an existing result id', async () => {
+    it('retrieves existing result correctly', async () => {
       const { core, data } = await loadFixture(deployResultHandlerFixture);
 
       await core.postResult(data.results[0], 0, data.proofs[0]);
@@ -143,7 +142,7 @@ describe('ResultHandler', () => {
       compareResults(retrievedResult, data.results[0]);
     });
 
-    it('should return the correct result for multiple posted results', async () => {
+    it('retrieves multiple results correctly', async () => {
       const { core, data } = await loadFixture(deployResultHandlerFixture);
 
       // Post two results
@@ -166,14 +165,14 @@ describe('ResultHandler', () => {
   });
 
   describe('verifyResult', () => {
-    it('should successfully verify a valid result', async () => {
+    it('verifies valid result successfully', async () => {
       const { core, data } = await loadFixture(deployResultHandlerFixture);
 
       const resultId = await core.verifyResult(data.results[0], 0, data.proofs[0]);
       expect(resultId).to.equal(deriveDataResultId(data.results[0]));
     });
 
-    it('should fail to verify a result with invalid proof', async () => {
+    it('reverts when proof is invalid', async () => {
       const { core, data } = await loadFixture(deployResultHandlerFixture);
 
       const resultId = deriveDataResultId(data.results[1]);

--- a/test/core/ResultHandler.test.ts
+++ b/test/core/ResultHandler.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { ethers, upgrades } from 'hardhat';
 
 import { compareResults } from '../helpers';
-import { computeResultLeafHash, deriveDataResultId, generateDataFixtures } from '../utils';
+import { ONE_DAY_IN_SECONDS, computeResultLeafHash, deriveDataResultId, generateDataFixtures } from '../utils';
 
 describe('ResultHandler', () => {
   async function deployResultHandlerFixture() {
@@ -38,7 +38,9 @@ describe('ResultHandler', () => {
     await prover.waitForDeployment();
 
     const CoreFactory = await ethers.getContractFactory('SedaCoreV1');
-    const core = await upgrades.deployProxy(CoreFactory, [await prover.getAddress()], { initializer: 'initialize' });
+    const core = await upgrades.deployProxy(CoreFactory, [await prover.getAddress(), ONE_DAY_IN_SECONDS], {
+      initializer: 'initialize',
+    });
     await core.waitForDeployment();
 
     return { core, data };

--- a/test/core/SedaCore.proxy.ts
+++ b/test/core/SedaCore.proxy.ts
@@ -34,7 +34,7 @@ describe('Proxy: SedaCore', () => {
   }
 
   describe('upgrade', () => {
-    it('should maintain state after upgrade', async () => {
+    it('maintains state after upgrade', async () => {
       const { prover, core, CoreV2Factory } = await loadFixture(deployProxyFixture);
 
       // Check initial state (using a relevant state variable from your SedaCore)
@@ -49,7 +49,7 @@ describe('Proxy: SedaCore', () => {
       expect(stateAfterUpgrade).to.equal(stateBeforeUpgrade);
     });
 
-    it('should maintain owner after upgrade', async () => {
+    it('maintains owner after upgrade', async () => {
       const { core: proxy, CoreV2Factory } = await loadFixture(deployProxyFixture);
       const [owner] = await ethers.getSigners();
 
@@ -65,7 +65,7 @@ describe('Proxy: SedaCore', () => {
       expect(ownerAfterUpgrade).to.equal(owner.address);
     });
 
-    it('should have new functionality after upgrade', async () => {
+    it('adds new functionality after upgrade', async () => {
       const { core: proxy, CoreV2Factory } = await loadFixture(deployProxyFixture);
 
       // Verify V1 doesn't have getVersion()

--- a/test/core/SedaCore.proxy.ts
+++ b/test/core/SedaCore.proxy.ts
@@ -1,6 +1,7 @@
 import { loadFixture } from '@nomicfoundation/hardhat-toolbox/network-helpers';
 import { expect } from 'chai';
 import { ethers, upgrades } from 'hardhat';
+import { ONE_DAY_IN_SECONDS } from '../utils';
 
 describe('Proxy: SedaCore', () => {
   async function deployProxyFixture() {
@@ -21,7 +22,9 @@ describe('Proxy: SedaCore', () => {
 
     // Deploy V1 through proxy
     const CoreV1Factory = await ethers.getContractFactory('SedaCoreV1', owner);
-    const core = await upgrades.deployProxy(CoreV1Factory, [await prover.getAddress()], { initializer: 'initialize' });
+    const core = await upgrades.deployProxy(CoreV1Factory, [await prover.getAddress(), ONE_DAY_IN_SECONDS], {
+      initializer: 'initialize',
+    });
     await core.waitForDeployment();
 
     // Get V2 factory

--- a/test/mocks/SedaPermissioned.test.ts
+++ b/test/mocks/SedaPermissioned.test.ts
@@ -21,7 +21,7 @@ describe('SedaPermissioned', () => {
     return { core, signers };
   }
 
-  it('should allow anyone to post a data request', async () => {
+  it('allows anyone to post a data request', async () => {
     const { core, signers } = await loadFixture(deployFixture);
     const { requests } = generateDataFixtures(1);
     const inputs = requests[0];
@@ -44,7 +44,7 @@ describe('SedaPermissioned', () => {
     compareRequests(storedRequest, inputs);
   });
 
-  it('should allow relayer to post a data result', async () => {
+  it('allows relayer to post a data result', async () => {
     const { core, signers } = await loadFixture(deployFixture);
     const { requests, results } = generateDataFixtures(1);
 
@@ -64,7 +64,7 @@ describe('SedaPermissioned', () => {
     expect(pendingRequests).to.be.empty;
   });
 
-  it('should handle pagination for pending requests', async () => {
+  it('handles pagination for pending requests', async () => {
     const { core, signers } = await loadFixture(deployFixture);
     const { requests } = generateDataFixtures(5);
 
@@ -88,7 +88,7 @@ describe('SedaPermissioned', () => {
     expect(requests1[1]).to.not.equal(requests2[1]);
   });
 
-  it('should maintain pending requests after posting results', async () => {
+  it('maintains pending requests after posting results', async () => {
     const { core, signers } = await loadFixture(deployFixture);
     const { requests, results } = generateDataFixtures(5);
 
@@ -117,7 +117,7 @@ describe('SedaPermissioned', () => {
     expect(pending).to.deep.include.members([requests[1], requests[3]]);
   });
 
-  it('should only allow relayer to post data result', async () => {
+  it('only allows relayer to post data result', async () => {
     const { core, signers } = await loadFixture(deployFixture);
     const { requests, results } = generateDataFixtures(1);
 
@@ -134,7 +134,7 @@ describe('SedaPermissioned', () => {
     await expect(core.connect(signers.relayer).postResult(results[0], 0, [])).to.not.be.reverted;
   });
 
-  it('should manage relayers correctly', async () => {
+  it('manages relayers correctly', async () => {
     const { core, signers } = await loadFixture(deployFixture);
 
     await expect(core.connect(signers.anyone).addRelayer(signers.anyone.address)).to.be.revertedWithCustomError(
@@ -154,7 +154,7 @@ describe('SedaPermissioned', () => {
     expect(await core.hasRole(await core.RELAYER_ROLE(), signers.anyone.address)).to.be.false;
   });
 
-  it('should get request and result data correctly', async () => {
+  it('gets request and result data correctly', async () => {
     const { core, signers } = await loadFixture(deployFixture);
     const { requests, results } = generateDataFixtures(1);
 
@@ -174,7 +174,7 @@ describe('SedaPermissioned', () => {
     await expect(core.getResult(nonExistentId)).to.be.revertedWithCustomError(core, 'ResultNotFound');
   });
 
-  it('should generate correct request and result IDs', async () => {
+  it('generates correct request and result IDs', async () => {
     const { core, signers } = await loadFixture(deployFixture);
     const { requests, results } = generateDataFixtures(1);
     const request = requests[0];
@@ -187,7 +187,7 @@ describe('SedaPermissioned', () => {
     expect(resultId).to.equal(deriveDataResultId(result));
   });
 
-  it('should enforce replication factor constraints', async () => {
+  it('enforces replication factor constraints', async () => {
     const { core, signers } = await loadFixture(deployFixture);
     const { requests } = generateDataFixtures(1);
 
@@ -206,7 +206,7 @@ describe('SedaPermissioned', () => {
     );
   });
 
-  it('should allow admin to set max replication factor', async () => {
+  it('allows admin to set max replication factor', async () => {
     const { core, signers } = await loadFixture(deployFixture);
     const newMaxReplicationFactor = 5;
 
@@ -219,7 +219,7 @@ describe('SedaPermissioned', () => {
     expect(await core.maxReplicationFactor()).to.equal(newMaxReplicationFactor);
   });
 
-  it('should allow admin to pause and unpause the contract', async () => {
+  it('allows admin to pause and unpause the contract', async () => {
     const { core, signers } = await loadFixture(deployFixture);
     const { requests } = generateDataFixtures(1);
 
@@ -245,7 +245,7 @@ describe('SedaPermissioned', () => {
     await expect(core.connect(signers.anyone).postRequest(requests[0])).to.not.be.reverted;
   });
 
-  it('should handle getPendingRequests with various offsets and limits', async () => {
+  it('handles getPendingRequests with various offsets and limits', async () => {
     const { core, signers } = await loadFixture(deployFixture);
     const { requests } = generateDataFixtures(10);
 
@@ -268,7 +268,7 @@ describe('SedaPermissioned', () => {
     expect(partialPage).to.have.lengthOf(2);
   });
 
-  it('should correctly remove pending requests when posting results in different orders', async () => {
+  it('correctly removes pending requests when posting results in different orders', async () => {
     const { core, signers } = await loadFixture(deployFixture);
     const { requests, results } = generateDataFixtures(5);
 

--- a/test/prover/Secp256k1Prover.proxy.ts
+++ b/test/prover/Secp256k1Prover.proxy.ts
@@ -27,8 +27,8 @@ describe('Proxy: Secp256k1Prover', () => {
     return { proxy, ProverV2Factory, ProverResettableFactory, owner, nonOwner, initialBatch };
   }
 
-  describe('V1 to V2 upgrade', () => {
-    it('should maintain state and ownership after upgrade', async () => {
+  describe('upgrade V1 to V2', () => {
+    it('maintains state and ownership after upgrade', async () => {
       const { proxy, ProverV2Factory, owner, initialBatch } = await loadFixture(deployProxyFixture);
 
       // Check initial state
@@ -43,7 +43,7 @@ describe('Proxy: Secp256k1Prover', () => {
       expect(await proxyV2.owner()).to.equal(owner.address);
     });
 
-    it('should add new functionality after upgrade', async () => {
+    it('adds new functionality after upgrade', async () => {
       const { proxy, ProverV2Factory } = await loadFixture(deployProxyFixture);
 
       // Verify V1 doesn't have getVersion()
@@ -57,7 +57,7 @@ describe('Proxy: Secp256k1Prover', () => {
       expect(await proxyV2.getVersion()).to.equal('2.0.0');
     });
 
-    it('should prevent non-owner initialization', async () => {
+    it('prevents non-owner initialization', async () => {
       const { proxy, ProverV2Factory, nonOwner } = await loadFixture(deployProxyFixture);
 
       const proxyV2 = (await upgrades.upgradeProxy(
@@ -71,7 +71,7 @@ describe('Proxy: Secp256k1Prover', () => {
       );
     });
 
-    it('should prevent double initialization', async () => {
+    it('prevents double initialization', async () => {
       const { proxy, ProverV2Factory } = await loadFixture(deployProxyFixture);
 
       const proxyV2 = await upgrades.upgradeProxy(await proxy.getAddress(), ProverV2Factory);
@@ -81,8 +81,8 @@ describe('Proxy: Secp256k1Prover', () => {
     });
   });
 
-  describe('Resettable variant', () => {
-    it('should allow owner to reset state with valid batch', async () => {
+  describe('resettable variant', () => {
+    it('allows owner to reset state with valid batch', async () => {
       const { proxy, ProverResettableFactory, initialBatch } = await loadFixture(deployProxyFixture);
       const proxyV2Resettable = await upgrades.upgradeProxy(await proxy.getAddress(), ProverResettableFactory);
 
@@ -102,7 +102,7 @@ describe('Proxy: Secp256k1Prover', () => {
       await expect(tx).to.emit(proxyV2Resettable, 'BatchPosted');
     });
 
-    it('should prevent non-owner from resetting state', async () => {
+    it('prevents non-owner from resetting state', async () => {
       const { proxy, ProverResettableFactory, nonOwner, initialBatch } = await loadFixture(deployProxyFixture);
       const proxyV2Resettable = (await upgrades.upgradeProxy(
         await proxy.getAddress(),

--- a/test/prover/Secp256k1ProverV1.test.ts
+++ b/test/prover/Secp256k1ProverV1.test.ts
@@ -92,8 +92,8 @@ describe('Secp256k1ProverV1', () => {
     return { newBatchId, newBatch, signatures };
   }
 
-  describe('getCurrentBatch', () => {
-    it('should return the current batch', async () => {
+  describe('batch management', () => {
+    it('retrieves current batch', async () => {
       const {
         prover,
         data: { initialBatch },
@@ -101,10 +101,8 @@ describe('Secp256k1ProverV1', () => {
       const lastBatchHeight = await prover.getLastBatchHeight();
       expect(lastBatchHeight).to.equal(initialBatch.batchHeight);
     });
-  });
 
-  describe('postBatch', () => {
-    it('should update a batch with 1 validator (75% voting power)', async () => {
+    it('updates batch with single validator (75% power)', async () => {
       const { prover, wallets, data } = await loadFixture(deployProverFixture);
 
       const { newBatch, signatures } = await generateAndSignBatch(wallets, data.initialBatch, [0]);
@@ -116,7 +114,7 @@ describe('Secp256k1ProverV1', () => {
       expect(lastValidatorsRoot).to.equal(newBatch.validatorsRoot);
     });
 
-    it('should update a batch with 3 validators (75% voting power)', async () => {
+    it('updates batch with three validators (75% power)', async () => {
       const { prover, wallets, data } = await loadFixture(deployProverFixture);
 
       const { newBatch, signatures } = await generateAndSignBatch(wallets, data.initialBatch, [1, 2, 3]);
@@ -128,7 +126,7 @@ describe('Secp256k1ProverV1', () => {
       expect(lastValidatorsRoot).to.equal(newBatch.validatorsRoot);
     });
 
-    it('should emit a BatchUpdated event', async () => {
+    it('emits BatchUpdated event', async () => {
       const { prover, wallets, data } = await loadFixture(deployProverFixture);
 
       const { newBatch, signatures, newBatchId } = await generateAndSignBatch(wallets, data.initialBatch, [0]);
@@ -141,7 +139,7 @@ describe('Secp256k1ProverV1', () => {
         .withArgs(newBatch.batchHeight, newBatchId, batchSender.address);
     });
 
-    it('should fail to update a batch with 1 validator (25% voting power)', async () => {
+    it('rejects batch with insufficient voting power', async () => {
       const { prover, wallets, data } = await loadFixture(deployProverFixture);
 
       const { newBatchId, newBatch } = generateNewBatchWithId(data.initialBatch);
@@ -156,7 +154,7 @@ describe('Secp256k1ProverV1', () => {
       expect(lastBatchHeight).to.equal(data.initialBatch.batchHeight);
     });
 
-    it('should fail to update a batch if mismatching signatures and proofs', async () => {
+    it('rejects batch with mismatched signatures and proofs', async () => {
       const { prover, wallets, data } = await loadFixture(deployProverFixture);
 
       const { newBatchId, newBatch } = generateNewBatchWithId(data.initialBatch);
@@ -168,7 +166,7 @@ describe('Secp256k1ProverV1', () => {
       );
     });
 
-    it('should fail to update a batch if invalid merkle proof', async () => {
+    it('rejects batch with invalid merkle proof', async () => {
       const { prover, wallets, data } = await loadFixture(deployProverFixture);
 
       const { newBatchId, newBatch } = generateNewBatchWithId(data.initialBatch);
@@ -186,7 +184,7 @@ describe('Secp256k1ProverV1', () => {
       );
     });
 
-    it('should fail to update a batch if invalid signature', async () => {
+    it('rejects batch with invalid signature', async () => {
       const { prover, wallets, data } = await loadFixture(deployProverFixture);
 
       const { newBatchId, newBatch } = generateNewBatchWithId(data.initialBatch);
@@ -198,7 +196,7 @@ describe('Secp256k1ProverV1', () => {
       );
     });
 
-    it('should fail to update a batch with lower batch height', async () => {
+    it('rejects batch with lower batch height', async () => {
       const { prover, wallets, data } = await loadFixture(deployProverFixture);
 
       const { newBatchId, newBatch } = generateNewBatchWithId(data.initialBatch);
@@ -211,7 +209,7 @@ describe('Secp256k1ProverV1', () => {
       );
     });
 
-    it('should update a batch with all validators (100% voting power)', async () => {
+    it('updates batch with full validator set', async () => {
       const { prover, wallets, data } = await loadFixture(deployProverFixture);
 
       const { newBatchId, newBatch } = generateNewBatchWithId(data.initialBatch);
@@ -224,8 +222,8 @@ describe('Secp256k1ProverV1', () => {
     });
   });
 
-  describe('verifyResultProof', () => {
-    it('should verify a valid result proof', async () => {
+  describe('result verification', () => {
+    it('verifies valid result proof', async () => {
       const { prover, wallets, data } = await loadFixture(deployProverFixture);
 
       // Generate a mock result and its proof
@@ -252,7 +250,7 @@ describe('Secp256k1ProverV1', () => {
       expect(sender).to.equal(batchSender.address);
     });
 
-    it('should reject an invalid result proof', async () => {
+    it('rejects invalid result proof', async () => {
       const { prover, wallets, data } = await loadFixture(deployProverFixture);
 
       // Generate a mock result and its proof
@@ -278,8 +276,8 @@ describe('Secp256k1ProverV1', () => {
     });
   });
 
-  describe('verifyResultProofForBatch', () => {
-    it('should verify a valid result proof', async () => {
+  describe('batch verification', () => {
+    it('verifies valid batch proof', async () => {
       const { prover, wallets, data } = await loadFixture(deployProverFixture);
 
       // Generate a mock result and its proof
@@ -303,7 +301,7 @@ describe('Secp256k1ProverV1', () => {
       expect(resultBatch).to.be.true;
     });
 
-    it('should reject an invalid result proof', async () => {
+    it('rejects invalid batch proof', async () => {
       const { prover, wallets, data } = await loadFixture(deployProverFixture);
 
       // Generate a mock result and its proof
@@ -353,17 +351,17 @@ describe('Secp256k1ProverV1', () => {
       }
     }
 
-    it('67 validators', async () => {
+    it('processes 67 validators', async () => {
       await runGasAnalysis(67, 100);
     });
 
-    it('20 validators', async () => {
+    it('processes 20 validators', async () => {
       await runGasAnalysis(20, 100);
     });
   });
 
-  describe('batch id', () => {
-    it('should generate the correct batch id for test vectors', async () => {
+  describe('batch identification', () => {
+    it('generates correct batch id for test vectors', async () => {
       const testBatch: ProverDataTypes.BatchStruct = {
         batchHeight: 4,
         blockHeight: 134,
@@ -384,7 +382,7 @@ describe('Secp256k1ProverV1', () => {
   });
 
   describe('pause functionality', () => {
-    it('should allow owner to pause and unpause', async () => {
+    it('allows owner to pause and unpause', async () => {
       const { prover } = await loadFixture(deployProverFixture);
       const [owner] = await ethers.getSigners();
 
@@ -403,7 +401,7 @@ describe('Secp256k1ProverV1', () => {
       expect(await prover.paused()).to.be.false;
     });
 
-    it('should prevent non-owner from pausing/unpausing', async () => {
+    it('prevents non-owner from pausing/unpausing', async () => {
       const { prover } = await loadFixture(deployProverFixture);
       const [, nonOwner] = await ethers.getSigners();
 
@@ -418,7 +416,7 @@ describe('Secp256k1ProverV1', () => {
       );
     });
 
-    it('should prevent postBatch while paused', async () => {
+    it('prevents postBatch while paused', async () => {
       const { prover, wallets, data } = await loadFixture(deployProverFixture);
       const [owner] = await ethers.getSigners();
 
@@ -433,7 +431,7 @@ describe('Secp256k1ProverV1', () => {
       );
     });
 
-    it('should resume operations after unpausing', async () => {
+    it('resumes operations after unpausing', async () => {
       const { prover, wallets, data } = await loadFixture(deployProverFixture);
       const [owner] = await ethers.getSigners();
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -2,6 +2,7 @@ import { ethers } from 'hardhat';
 import type { CoreRequestTypes, CoreResultTypes, ProverDataTypes } from '../ts-types';
 
 export const SEDA_DATA_TYPES_VERSION = '0.0.1';
+export const ONE_DAY_IN_SECONDS = 24 * 60 * 60;
 
 const RESULT_DOMAIN_SEPARATOR = '0x00';
 const SECP256K1_DOMAIN_SEPARATOR = '0x01';


### PR DESCRIPTION
## Motivation

Add ability to withdraw fees from timed-out requests. This lets users get their funds back if requests are not processed in time and avoids having funs in stale requests.

## Explanation of Changes

- Added `withdrawTimedOutRequest` function to get fees back from timed-out requests
- Added timeout period settings:
  - Can be set during initialization
  - Owner can update it later
- Added tests for all new features
- Improved error messages

## Related PRs and Issues

Closes #81 

