### PR TITLE
fix: duplicate batch signatures

### DIFF
--- a/contracts/provers/abstract/ProverBase.sol
+++ b/contracts/provers/abstract/ProverBase.sol
@@ -18,6 +18,9 @@ abstract contract ProverBase is IProver {
     /// @notice Error thrown when batch height <= lastBatchHeight, enforcing sequential processing
     error InvalidBatchHeight();
 
+    /// @notice Error thrown when validator's address is not strictly increasing
+    error InvalidValidatorOrder();
+
     /// @notice Error thrown when signature verification fails for a validator's signed batch
     error InvalidSignature();
 


### PR DESCRIPTION
## Motivation

The contract failed to enforce uniqueness in validator signatures. This allowed a malicious validator to submit multiple identical signatures, each counted separately, effectively inflating their voting power and bypassing the consensus threshold. If exploited, this would allow a single validator to approve batches unilaterally, compromising the integrity of the cross-chain verification system.

## Explanation of Changes

The fix enforces a strict validation rule by requiring an ordered list of validator signatures and performing a strict comparison to detect and reject duplicates. Instead of using a mapping to track previously seen validators, we ensure that:

-  Signatures and validator proofs must be provided in a strictly ordered manner – This simplifies the check and ensures that any duplicate validator entry appears consecutively.
- A strict comparison is performed between adjacent entries – If a validator appears more than once in the ordered list, the transaction is reverted.

This approach makes the validation mechanism more efficient and predictable, preventing duplicate signatures while improving gas efficiency.

## Testing

Added a test case that submits batches with duplicate validator signatures to confirm they are correctly rejected.

## Related PRs and Issues

N/A.

