### PR TITLE
feat: keep track of fee sender addresses

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -3,5 +3,6 @@ module.exports = {
     grep: '[Gg]as.*[Aa]nalysis',
     invert: true,
   },
-  skipFiles: ['mocks/', 'interfaces/', 'libraries/SedaDataTypes.sol'],
+  skipFiles: ['mocks/', 'interfaces/', 'libraries/SedaDataTypes.sol', 'test/MaliciousRecipient.sol'],
+  modifierWhitelist: ['initializer', 'onlyInitializing'],
 };

--- a/contracts/core/abstract/RequestHandlerBase.sol
+++ b/contracts/core/abstract/RequestHandlerBase.sol
@@ -82,7 +82,7 @@ abstract contract RequestHandlerBase is IRequestHandler {
     /// @notice Returns the storage struct for the contract
     /// @dev Uses ERC-7201 storage pattern to access the storage struct at a specific slot
     /// @return s The storage struct containing the contract's state variables
-    function _requestHandlerStorage() private pure returns (RequestHandlerStorage storage s) {
+    function _requestHandlerStorage() internal pure returns (RequestHandlerStorage storage s) {
         bytes32 slot = REQUEST_HANDLER_STORAGE_SLOT;
         // solhint-disable-next-line no-inline-assembly
         assembly {

--- a/contracts/core/abstract/ResultHandlerBase.sol
+++ b/contracts/core/abstract/ResultHandlerBase.sol
@@ -96,6 +96,13 @@ abstract contract ResultHandlerBase is IResultHandler, Initializable {
         return result;
     }
 
+    /// @notice Checks if a result exists for a given request ID
+    /// @param requestId The unique identifier of the request
+    /// @return A boolean indicating whether a result exists for the request
+    function hasResult(bytes32 requestId) public view returns (bool) {
+        return _resultHandlerStorage().results[requestId].drId != bytes32(0);
+    }
+
     // ============ Internal Functions ============
 
     /// @notice Posts a result and returns both the result ID and batch sender address

--- a/contracts/core/abstract/ResultHandlerBase.sol
+++ b/contracts/core/abstract/ResultHandlerBase.sol
@@ -141,7 +141,7 @@ abstract contract ResultHandlerBase is IResultHandler, Initializable {
     /// @notice Returns the storage struct for the contract
     /// @dev Uses ERC-7201 storage pattern to access the storage struct at a specific slot
     /// @return s The storage struct containing the contract's state variables
-    function _resultHandlerStorage() private pure returns (ResultHandlerStorage storage s) {
+    function _resultHandlerStorage() internal pure returns (ResultHandlerStorage storage s) {
         bytes32 slot = RESULT_HANDLER_STORAGE_SLOT;
         // solhint-disable-next-line no-inline-assembly
         assembly {

--- a/contracts/fees/SedaFeeManager.sol
+++ b/contracts/fees/SedaFeeManager.sol
@@ -5,7 +5,8 @@ import {IFeeManager} from "../interfaces/IFeeManager.sol";
 
 /// @title SedaFeeManager
 /// @notice Manages fee distribution and withdrawals for the Seda protocol
-/// @dev Implements a pull-based payment system where recipients can withdraw their fees
+/// @dev Implements a pull-based payment system where recipients can withdraw their fees.
+///      Uses a mapping to track pending fees for each address and ensures atomic fee distribution.
 contract SedaFeeManager is IFeeManager {
     // Mapping to track pending fees for each address
     mapping(address => uint256) public pendingFees;

--- a/contracts/interfaces/ISedaCore.sol
+++ b/contracts/interfaces/ISedaCore.sol
@@ -50,14 +50,19 @@ interface ISedaCore is IResultHandler, IRequestHandler {
     /// @param newTimeoutPeriod The new timeout period in seconds
     event TimeoutPeriodUpdated(uint256 newTimeoutPeriod);
 
-    /// @notice Error thrown when attempting to increase fees but no fees were actually increased
-    error NoFeesUpdated();
-
     /// @notice Error thrown when the fee amount is not equal to the sum of the request, result, and batch fees
     error InvalidFeeAmount();
 
     /// @notice Error thrown when attempting to set the timeout period to zero
     error InvalidTimeoutPeriod();
+
+    /// @notice Error thrown when attempting to increase fees but no fees were actually increased
+    /// @param requestId The ID of the request that was attempted to be updated
+    error NoFeesUpdated(bytes32 requestId);
+
+    /// @notice Error thrown when a request has already been resolved
+    /// @param requestId The ID of the request that was attempted to be resolved
+    error RequestAlreadyResolved(bytes32 requestId);
 
     /// @notice Error thrown when a request has not reached its timeout period yet
     /// @param requestId The ID of the request that was attempted to be withdrawn

--- a/contracts/interfaces/ISedaCore.sol
+++ b/contracts/interfaces/ISedaCore.sol
@@ -40,21 +40,18 @@ interface ISedaCore is IResultHandler, IRequestHandler {
     /// @param amount The amount of fees distributed to the recipient
     event FeeDistributed(bytes32 indexed requestId, address indexed recipient, uint256 amount, FeeType indexed feeType);
 
-    /// @notice Emitted when fees are increased for a data request
-    /// @param requestId The unique identifier for the data request
-    /// @param additionalRequestFee The additional request fee
-    /// @param additionalResultFee The additional result fee
-    /// @param additionalBatchFee The additional batch fee
-    event FeesIncreased(
-        bytes32 indexed requestId,
-        uint256 additionalRequestFee,
-        uint256 additionalResultFee,
-        uint256 additionalBatchFee
-    );
+    /// @notice Emitted when fees are increased for an existing request
+    /// @param requestId The unique identifier of the request being updated
+    /// @param amount The absolute fee amount being increased
+    /// @param feeType The type of fee being increased (REQUEST, RESULT, or BATCH)
+    event FeeUpdated(bytes32 indexed requestId, uint256 amount, FeeType feeType);
 
     /// @notice Emitted when the timeout period is updated
     /// @param newTimeoutPeriod The new timeout period in seconds
     event TimeoutPeriodUpdated(uint256 newTimeoutPeriod);
+
+    /// @notice Error thrown when attempting to increase fees but no fees were actually increased
+    error NoFeesUpdated();
 
     /// @notice Error thrown when the fee amount is not equal to the sum of the request, result, and batch fees
     error InvalidFeeAmount();

--- a/contracts/interfaces/ISedaCore.sol
+++ b/contracts/interfaces/ISedaCore.sol
@@ -40,10 +40,10 @@ interface ISedaCore is IResultHandler, IRequestHandler {
     /// @param amount The amount of fees distributed to the recipient
     event FeeDistributed(bytes32 indexed requestId, address indexed recipient, uint256 amount, FeeType indexed feeType);
 
-    /// @notice Emitted when fees are increased for an existing request
+    /// @notice Emitted when fees are updated for an existing request
     /// @param requestId The unique identifier of the request being updated
     /// @param amount The absolute fee amount being increased
-    /// @param feeType The type of fee being increased (REQUEST, RESULT, or BATCH)
+    /// @param feeType The type of fee being updated (REQUEST, RESULT, or BATCH)
     event FeeUpdated(bytes32 indexed requestId, uint256 amount, FeeType feeType);
 
     /// @notice Emitted when the timeout period is updated
@@ -56,7 +56,7 @@ interface ISedaCore is IResultHandler, IRequestHandler {
     /// @notice Error thrown when attempting to set the timeout period to zero
     error InvalidTimeoutPeriod();
 
-    /// @notice Error thrown when attempting to increase fees but no fees were actually increased
+    /// @notice Error thrown when attempting to update fees but no fees were actually changed
     /// @param requestId The ID of the request that was attempted to be updated
     error NoFeesUpdated(bytes32 requestId);
 

--- a/test/core/SedaCoreV1.test.ts
+++ b/test/core/SedaCoreV1.test.ts
@@ -605,9 +605,9 @@ describe('SedaCoreV1', () => {
         };
         const totalFee = fees.request + fees.result + fees.batch;
         const additionalFees = {
-          request: ethers.parseEther('0.5'),
-          result: ethers.parseEther('1.0'),
-          batch: ethers.parseEther('1.5'),
+          request: ethers.parseEther('1.5'),
+          result: ethers.parseEther('3.0'),
+          batch: ethers.parseEther('4.5'),
         };
         const totalAdditionalFee = additionalFees.request + additionalFees.result + additionalFees.batch;
         const [requestor, resultSubmitter, batchSubmitter] = await ethers.getSigners();
@@ -633,8 +633,8 @@ describe('SedaCoreV1', () => {
 
         // Calculate expected request fee distribution
         const totalGas = BigInt(data.requests[1].execGasLimit) + BigInt(data.requests[1].tallyGasLimit);
-        const expectedPayback = ((fees.request + additionalFees.request) * BigInt(data.results[1].gasUsed)) / totalGas;
-        const expectedRefund = fees.request + additionalFees.request - expectedPayback;
+        const expectedPayback = (additionalFees.request * BigInt(data.results[1].gasUsed)) / totalGas;
+        const expectedRefund = additionalFees.request - expectedPayback;
 
         // Submit result
         await (core.connect(resultSubmitter) as SedaCoreV1).postResult(data.results[1], 1, data.proofs[1]);
@@ -645,14 +645,14 @@ describe('SedaCoreV1', () => {
 
         // Check pending fees before withdrawal
         const pendingResultFees = await feeManagerContract.getPendingFees(resultSubmitter.address);
-        expect(pendingResultFees).to.equal(fees.result + additionalFees.result);
+        expect(pendingResultFees).to.equal(additionalFees.result);
 
         const pendingBatchFees = await feeManagerContract.getPendingFees(batchSubmitter.address);
-        expect(pendingBatchFees).to.equal(fees.batch + additionalFees.batch);
+        expect(pendingBatchFees).to.equal(additionalFees.batch);
 
         // Check if payback address has expected fees
         if (data.results[1].paybackAddress.length === 20) {
-          const pendingPaybackFees = await feeManagerContract.getPendingFees(data.results[1].paybackAddress);
+          const pendingPaybackFees = await feeManagerContract.getPendingFees(data.results[1].paybackAddress.toString());
           expect(pendingPaybackFees).to.equal(expectedPayback);
         }
 

--- a/test/gas/SedaCoreV1.gas.test.ts
+++ b/test/gas/SedaCoreV1.gas.test.ts
@@ -170,9 +170,9 @@ describe('SedaCoreV1 Gas Analysis', () => {
 
       // Test increaseFees
       const additionalFees = {
-        request: ethers.parseEther('0.002'),
-        result: ethers.parseEther('0.001'),
-        batch: ethers.parseEther('0.0005'),
+        request: requestFee + ethers.parseEther('0.002'),
+        result: resultFee + ethers.parseEther('0.001'),
+        batch: batchFee + ethers.parseEther('0.0005'),
       };
 
       const increaseFeesGas = await measureGas(


### PR DESCRIPTION
## Motivation

This PR introduces several improvements to the fee handling system and request management in the core contracts:

1. Enable more flexible fee management by allowing different fee addresses for request, result, and batch fees
2. Allow duplicate unresolved post requests to update fees accordingly
3. Increase test coverage and improve code organization

These changes help prevent front-running attacks since posting requests or increasing fees will always use the highest fee amount.

## Explanation of Changes

The changes include:

1. **Fee Management Improvements**:
   - Allow different fee addresses for request, result, and batch fees
   - Use absolute values instead of increments for fees (clearer and safer)
   - Better fee distribution for multiple recipients

2. **Request Handling**:
   - Allow duplicate post requests if not yet resolved
   - Better request lifecycle management
   - Better validation of request states

3. **Storage Access**:
   - Changed storage functions from `private` to `internal` in base contracts

4. **Code Quality**:
   - Better comments and docs
   - Better function organization
   - Better NatSpec coverage

## Testing

All changes are tested:

1. **Fee Management Tests**:
   ```bash
   npx hardhat test test/core/SedaCoreV1.test.ts
   ```
   - Different fee address scenarios
   - Absolute fee handling
   - Fee distribution

2. **Request Handling Tests**:
   ```bash
   npx hardhat test
   ```
   - Duplicate request scenarios
   - Request lifecycle
   - Edge cases

3. **Coverage**:
   ```bash
   npx hardhat coverage
   ```
   - Better core coverage
   - Edge case testing
   - Better assertions

## Related PRs and Issues

N/A