### PR TITLE
refactor: get pending req details

### DIFF
--- a/contracts/core/SedaCoreV1.sol
+++ b/contracts/core/SedaCoreV1.sol
@@ -401,6 +401,13 @@ contract SedaCoreV1 is
         return address(_storageV1().feeManager);
     }
 
+    /// @notice Returns the details of a pending request
+    /// @param requestId The ID of the request to retrieve details for
+    /// @return The details of the pending request
+    function getPendingRequestDetails(bytes32 requestId) external view returns (RequestDetails memory) {
+        return _storageV1().requestDetails[requestId];
+    }
+
     /// @notice Retrieves a list of active requests
     /// @dev This function is gas-intensive due to iteration over the pendingRequests array.
     /// Users should be cautious when using high `limit` values in production environments, as it can result in high gas consumption.
@@ -607,7 +614,7 @@ contract SedaCoreV1 is
     /// @param totalFees The total amount of fees expected for this transaction
     function _validateFees(uint256 totalFees) private view {
         if (msg.value != totalFees) {
-            revert InvalidFeeAmount();
+            revert InvalidFeeAmount(msg.value, totalFees);
         }
 
         if (msg.value > 0 && address(_storageV1().feeManager) == address(0)) {

--- a/contracts/core/SedaCoreV1.sol
+++ b/contracts/core/SedaCoreV1.sol
@@ -510,8 +510,10 @@ contract SedaCoreV1 is
             if (payableAddress == address(0)) {
                 requestorRefund += requestDetails.requestFee;
             } else {
-                // Split request fee proportionally based on gas used vs gas limit
+                // Calculate submitter fee proportionally based on gas used vs gas limit
                 uint256 submitterFee = (result.gasUsed * requestDetails.requestFee) / requestDetails.gasLimit;
+                // Sanity check: limit the fee as a safeguard (gasUsed should never exceed gasLimit)
+                if (submitterFee > requestDetails.requestFee) submitterFee = requestDetails.requestFee;
                 if (submitterFee > 0) {
                     recipients[recipientCount] = payableAddress;
                     amounts[recipientCount] = submitterFee;

--- a/contracts/interfaces/ISedaCore.sol
+++ b/contracts/interfaces/ISedaCore.sol
@@ -51,7 +51,9 @@ interface ISedaCore is IResultHandler, IRequestHandler {
     event TimeoutPeriodUpdated(uint256 newTimeoutPeriod);
 
     /// @notice Error thrown when the fee amount is not equal to the sum of the request, result, and batch fees
-    error InvalidFeeAmount();
+    /// @param providedFee The fee amount provided by the user
+    /// @param expectedFee The expected fee amount
+    error InvalidFeeAmount(uint256 providedFee, uint256 expectedFee);
 
     /// @notice Error thrown when attempting to set the timeout period to zero
     error InvalidTimeoutPeriod();


### PR DESCRIPTION
## Motivation

Allow solvers to fetch request details by request id. It should help them to better assess actions to be made based on fees and even timeout.

## Explanation of Changes

Added a getter function to fetch pending request details for a given request id.

## Testing

Added a few tests for fetching existing pending request and non-existent.

## Related PRs and Issues

N.A.
