### PR TITLE
feat(tasks): add update proxy task

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,13 +294,15 @@ AVAILABLE TASKS:
 
   deploy:all                    Deploys the Secp256k1ProverV1 and SedaCoreV1 contracts
   deploy:core                   Deploys the SedaCoreV1 contract
-  deploy:dev:all-reset          Deploys the Secp256k1ProverV1 and SedaCoreV1 contracts (only for testing)
-  deploy:dev:permissioned       Deploys the Permissioned SEDA contract (only for testing)
-  deploy:dev:prover-reset       Deploys the Secp256k1ProverResettable contract (only for testing)
   deploy:fee-manager            Deploys the SedaFeeManager contract
   deploy:prover                 Deploys the Secp256k1ProverV1 contract
-  post-request                  Post a data request to a ISedaCore contract with attached funds
-  reset-prover                  Resets a Secp256k1ProverResettable contract to a specified batch (only for testing)
+  dev:deploy:all                Deploys the Secp256k1ProverResettable and SedaCoreV1 contracts (only for testing)
+  dev:deploy:permissioned       Deploys the Permissioned SEDA contract (only for testing)
+  dev:deploy:prover             Deploys the Secp256k1ProverResettable contract (only for testing)
+  dev:reset-prover              Resets a Secp256k1ProverResettable contract to a specified batch (only for testing)
+  utils:post-request            Post a data request to a ISedaCore contract with attached funds
+  utils:upgrade-proxy           Deploys and upgrades a proxy implementation contract
+```
 
 seda: Deploy and interact with SEDA contracts
 

--- a/config/networks.ts
+++ b/config/networks.ts
@@ -21,16 +21,6 @@ export const networks: Networks = {
       browserUrl: 'https://sepolia.basescan.org',
     },
   },
-  berachainBartio: {
-    accounts: 'EVM_PRIVATE_KEY',
-    chainId: 80084,
-    url: 'https://bartio.rpc.berachain.com/',
-    etherscan: {
-      apiKey: 'NO_API_KEY',
-      apiUrl: 'https://api.routescan.io/v2/network/testnet/evm/80084/etherscan/api',
-      browserUrl: 'https://bartio.beratrail.io',
-    },
-  },
   flowTestnet: {
     accounts: 'EVM_PRIVATE_KEY',
     chainId: 545,

--- a/scripts/testDeployments.ts
+++ b/scripts/testDeployments.ts
@@ -4,9 +4,9 @@ import hre from 'hardhat';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 
 import { deploySedaCore } from '../tasks/tasks/deploy/core';
-import { deployResettableProver } from '../tasks/tasks/deploy/dev/resettableProver';
 import { deployFeeManager } from '../tasks/tasks/deploy/feeManager';
 import { deploySecp256k1Prover } from '../tasks/tasks/deploy/prover';
+import { deployResettableProver } from '../tasks/tasks/dev/resettableProver';
 
 async function main() {
   console.log('🧪 Testing All Deployment Functions');

--- a/tasks/common/config.ts
+++ b/tasks/common/config.ts
@@ -22,6 +22,7 @@ const LOGGER_CONFIG = {
     params: '📜',
     default: '🔹',
     meta: '🌟',
+    upgrade: '🔄',
   },
   META_BORDER: '━',
 } as const;

--- a/tasks/common/deploy/proxy.ts
+++ b/tasks/common/deploy/proxy.ts
@@ -35,3 +35,22 @@ export async function deployProxyContract<T extends keyof UupsContracts>(
     contractImplAddress,
   };
 }
+
+export async function upgradeProxyContract(
+  hre: HardhatRuntimeEnvironment,
+  proxyAddress: string,
+  contractName: string,
+  signer: Signer,
+) {
+  const ContractFactory = await hre.ethers.getContractFactory(contractName, signer);
+  const upgraded = await hre.upgrades.upgradeProxy(proxyAddress, ContractFactory, {
+    kind: 'uups',
+  });
+  await upgraded.waitForDeployment();
+
+  const contractImplAddress = await hre.upgrades.erc1967.getImplementationAddress(await upgraded.getAddress());
+
+  return {
+    contractImplAddress,
+  };
+}

--- a/tasks/common/logger.ts
+++ b/tasks/common/logger.ts
@@ -1,7 +1,7 @@
 import { CONFIG } from './config';
 
 type LogLevel = 'info' | 'success' | 'error' | 'warn';
-type SectionType = 'config' | 'deploy' | 'files' | 'test' | 'verify' | 'default' | 'params' | 'meta';
+type SectionType = 'config' | 'deploy' | 'files' | 'test' | 'verify' | 'default' | 'params' | 'meta' | 'upgrade';
 
 class Logger {
   private prefix?: string;

--- a/tasks/index.ts
+++ b/tasks/index.ts
@@ -10,13 +10,13 @@ import './tasks/deploy/core';
 import './tasks/deploy/prover';
 import './tasks/deploy/feeManager';
 import './tasks/deploy/all';
-import './tasks/deploy/dev/permissioned';
-import './tasks/deploy/dev/resettableProver';
-import './tasks/deploy/dev/allResettable';
 
-// Upgrade task
-import './tasks/upgrade';
+// Development tasks
+import './tasks/dev/permissioned';
+import './tasks/dev/resettableProver';
+import './tasks/dev/allResettable';
+import './tasks/dev/resetProver';
 
-// Request tasks
-import './tasks/postRequest';
-import './tasks/resetProver';
+// Utils tasks
+import './tasks/utils/postRequest';
+import './tasks/utils/proxyUpgrade';

--- a/tasks/index.ts
+++ b/tasks/index.ts
@@ -14,6 +14,9 @@ import './tasks/deploy/dev/permissioned';
 import './tasks/deploy/dev/resettableProver';
 import './tasks/deploy/dev/allResettable';
 
+// Upgrade task
+import './tasks/upgrade';
+
 // Request tasks
 import './tasks/postRequest';
 import './tasks/resetProver';

--- a/tasks/tasks/dev/allResettable.ts
+++ b/tasks/tasks/dev/allResettable.ts
@@ -1,14 +1,14 @@
 import { types } from 'hardhat/config';
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
 
-import { sedaScope } from '../../..';
-import { logger } from '../../../common/logger';
-import { deploySedaCore } from '../core';
-import { deployFeeManager } from '../feeManager';
+import { sedaScope } from '../..';
+import { logger } from '../../common/logger';
+import { deploySedaCore } from '../deploy/core';
+import { deployFeeManager } from '../deploy/feeManager';
 import { deployResettableProver } from './resettableProver';
 
 sedaScope
-  .task('deploy:dev:all-reset', 'Deploys the Secp256k1ProverV1 and SedaCoreV1 contracts')
+  .task('dev:deploy:all', 'Deploys the Secp256k1ProverResettable and SedaCoreV1 contracts (only for testing)')
   .addParam('params', 'The parameters file to use', undefined, types.string)
   .addFlag('reset', 'Replace existing deployment files')
   .addFlag('verify', 'Verify the contract on etherscan')
@@ -32,7 +32,7 @@ export async function deployAll(
   });
 
   // 1. Deploy Secp256k1Prover
-  logger.section('1. Deploy Secp256k1Prover contracts', 'meta');
+  logger.section('1. Deploy Secp256k1ProverResettable contracts', 'meta');
   const { contractAddress: proverAddress } = await deployResettableProver(hre, {
     params: options.params,
     feeManagerAddress: feeManagerAddress,

--- a/tasks/tasks/dev/permissioned.ts
+++ b/tasks/tasks/dev/permissioned.ts
@@ -8,12 +8,12 @@ import {
   logConstructorArgs,
   logDeploymentConfig,
   readAndValidateParams,
-} from '../../../common/deploy/helpers';
-import { getNetworkKey } from '../../../common/utils';
-import { sedaScope } from '../../../index';
+} from '../../common/deploy/helpers';
+import { getNetworkKey } from '../../common/utils';
+import { sedaScope } from '../../index';
 
 sedaScope
-  .task('deploy:dev:permissioned', 'Deploys the Permissioned SEDA contract (only for testing)')
+  .task('dev:deploy:permissioned', 'Deploys the Permissioned SEDA contract (only for testing)')
   .addOptionalParam('maxReplicationFactor', 'The maximum replication factor', undefined, types.int)
   .addOptionalParam('params', 'The parameters file to use', undefined, types.string)
   .addFlag('reset', 'Replace existing deployment files')

--- a/tasks/tasks/dev/resetProver.ts
+++ b/tasks/tasks/dev/resetProver.ts
@@ -1,8 +1,8 @@
-import { logger } from '../common/logger';
-import { sedaScope } from '../index';
+import { logger } from '../../common/logger';
+import { sedaScope } from '../../index';
 
 sedaScope
-  .task('reset-prover', 'Resets a Secp256k1ProverResettable contract to a specified batch (only for testing)')
+  .task('dev:reset-prover', 'Resets a Secp256k1ProverResettable contract to a specified batch (only for testing)')
   .addParam('prover', 'The address of the resettable prover contract')
   .addParam('height', 'The batch height to reset to')
   .addParam('validatorsRoot', 'The validators root hash')

--- a/tasks/tasks/dev/resettableProver.ts
+++ b/tasks/tasks/dev/resettableProver.ts
@@ -1,11 +1,11 @@
 import { types } from 'hardhat/config';
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
 
-import { sedaScope } from '../../../index';
-import { deployProver } from '../proverBase';
+import { sedaScope } from '../../index';
+import { deployProver } from '../deploy/proverBase';
 
 sedaScope
-  .task('deploy:dev:prover-reset', 'Deploys the Secp256k1ProverResettable contract (only for testing)')
+  .task('dev:deploy:prover', 'Deploys the Secp256k1ProverResettable contract (only for testing)')
   .addParam('params', 'The parameters file to use', undefined, types.string)
   .addOptionalParam('maxBatchAge', 'The maximum allowed age difference between batches', undefined, types.bigint)
   .addOptionalParam('feeManagerAddress', 'The address of the FeeManager contract', undefined, types.string)

--- a/tasks/tasks/upgrade/index.ts
+++ b/tasks/tasks/upgrade/index.ts
@@ -1,0 +1,93 @@
+import { types } from 'hardhat/config';
+import type { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+import {
+  confirmDeployment,
+  logDeploymentConfig,
+  upgradeAndVerifyContractWithProxy,
+  verifyContract,
+} from '../../common/deploy/helpers';
+import type { UupsContracts } from '../../common/deploy/proxy';
+import { logger } from '../../common/logger';
+import { getNetworkKey } from '../../common/utils';
+import { sedaScope } from '../../index';
+
+/**
+ * Example usage for this task:
+ *
+ * 1. Start local node:
+ *    `npx hardhat node`
+ *
+ * 2. Deploy initial contract:
+ *    `bun run seda deploy:prover --params deployments/parameters-example.json --network local`
+ *
+ * 3. Copy the proxy address from deployment output
+ *
+ * 4. Run upgrade:
+ *    `bun run seda upgrade:dev <proxy-address> MockSecp256k1ProverV2 --network local`
+ *
+ * Example usage for Base Sepolia Testnet:
+ * - Deploy: `bun run seda deploy:prover --params deployments/parameters-example.json --verify --network baseSepolia`
+ * - Upgrade: `bun run seda upgrade:dev 0xC1b213990a78De8E8A4efAFd2F47406d65481C45 MockSecp256k1ProverV2 --verify --network baseSepolia`
+ */
+
+sedaScope
+  .task('upgrade:dev', 'Deploys and upgrades a proxy implementation contract')
+  .addPositionalParam('proxy', 'The proxy address to upgrade', undefined, types.string)
+  .addPositionalParam('contractName', 'The contract name to upgrade', undefined, types.string)
+  .addOptionalParam('args', 'The initialize arguments to use', undefined, types.string)
+  .addFlag('reset', 'Replace existing deployment files')
+  .addFlag('verify', 'Verify the contract on etherscan')
+  .setAction(async (taskArgs, hre) => {
+    await upgradeProver(hre, taskArgs);
+  });
+
+export async function upgradeProver(
+  hre: HardhatRuntimeEnvironment,
+  options: {
+    contractName: string;
+    proxy: string;
+    args: string | undefined;
+    reset?: boolean;
+    verify?: boolean;
+  },
+): Promise<{ contractImplAddress: string }> {
+  const contractName = options.contractName;
+
+  // Configuration
+  const [owner] = await hre.ethers.getSigners();
+  await logDeploymentConfig(hre, contractName, owner);
+
+  // Confirm deployment (if required)
+  const networkKey = await getNetworkKey(hre);
+  await confirmDeployment(networkKey, options.reset);
+
+  // Deploy and verify
+  const result = await upgradeAndVerifyContractWithProxy(
+    hre,
+    options.proxy,
+    contractName as keyof UupsContracts,
+    owner,
+  );
+
+  // Call the initialize function
+  logger.section('Initializing implementation contract', 'upgrade');
+  logger.info(`Initialize args: ${options.args}`);
+  const proxy = await hre.ethers.getContractAt(contractName, options.proxy, owner);
+  const tx = options.args ? await proxy.initialize(options.args) : await proxy.initialize();
+  logger.info(`Transaction: ${tx.hash}`);
+  await tx.wait();
+
+  if (options.verify) {
+    await verifyContract(hre, result.contractImplAddress);
+    await verifyContract(hre, options.proxy);
+  }
+
+  // Example: Query contract version (function in the new implementation)
+  // const version = await proxy.getVersion();
+  // logger.info(`Contract version: ${version}`);
+
+  logger.success('Upgrade complete');
+
+  return result;
+}

--- a/tasks/tasks/utils/postRequest.ts
+++ b/tasks/tasks/utils/postRequest.ts
@@ -1,9 +1,9 @@
 import { parseUnits } from 'ethers';
-import { logger } from '../common/logger';
-import { sedaScope } from '../index';
+import { logger } from '../../common/logger';
+import { sedaScope } from '../../index';
 
 sedaScope
-  .task('post-request', 'Post a data request to a ISedaCore contract with attached funds')
+  .task('utils:post-request', 'Post a data request to an ISedaCore contract with attached funds')
   .addParam('core', 'The address of the SedaCore contract')
   .addOptionalParam('requestFee', 'The fee for executing the request in gwei', '25000')
   .addOptionalParam('resultFee', 'The fee for posting the result in gwei', '10000')

--- a/tasks/tasks/utils/proxyUpgrade.ts
+++ b/tasks/tasks/utils/proxyUpgrade.ts
@@ -24,15 +24,15 @@ import { sedaScope } from '../../index';
  * 3. Copy the proxy address from deployment output
  *
  * 4. Run upgrade:
- *    `bun run seda upgrade:dev <proxy-address> MockSecp256k1ProverV2 --network local`
+ *    `bun run seda utils:upgrade-proxy <proxy-address> MockSecp256k1ProverV2 --network local`
  *
  * Example usage for Base Sepolia Testnet:
  * - Deploy: `bun run seda deploy:prover --params deployments/parameters-example.json --verify --network baseSepolia`
- * - Upgrade: `bun run seda upgrade:dev 0xC1b213990a78De8E8A4efAFd2F47406d65481C45 MockSecp256k1ProverV2 --verify --network baseSepolia`
+ * - Upgrade: `bun run seda utils:upgrade-proxy 0xC1b213990a78De8E8A4efAFd2F47406d65481C45 MockSecp256k1ProverV2 --verify --network baseSepolia`
  */
 
 sedaScope
-  .task('upgrade:dev', 'Deploys and upgrades a proxy implementation contract')
+  .task('utils:upgrade-proxy', 'Deploys and upgrades a proxy implementation contract')
   .addPositionalParam('proxy', 'The proxy address to upgrade', undefined, types.string)
   .addPositionalParam('contractName', 'The contract name to upgrade', undefined, types.string)
   .addOptionalParam('args', 'The initialize arguments to use', undefined, types.string)


### PR DESCRIPTION
## Motivation

Having a proxy upgrade task readily available is valuable for ensuring we can quickly respond to unexpected scenarios, such as urgent bug fixes, contract recovery, or protocol upgrades. Proactively including this functionality helps minimize downtime and risk in the event that a proxy upgrade becomes necessary.

## Explanation of Changes

- Added support for proxy upgrades within the tasks, enabling upgrades of contract implementations via UUPS proxy patterns.
- Reorganized task names for improved clarity and maintainability.
- Updated supported networks configuration to ensure compatibility with the latest deployments.

This PR does not change any contract logic and therefore I did not bump the version. :)

## Testing

- Verified the new proxy upgrade task by running it against test deployments and confirming that the proxy implementation address updates as expected.
- Ran the full suite of existing tasks to ensure no regressions were introduced by the reorganization.
- Used the following command to test the proxy upgrade task:

```
bun run seda utils:upgrade-proxy 0xc1b213990a78de8e8a4efafd2f47406d65481c45 MockSecp256k1ProverV2 --verify --network baseSepolia
```

https://sepolia.basescan.org/address/0xc1b213990a78de8e8a4efafd2f47406d65481c45#readProxyContract

## Related PRs and Issues

- N/A